### PR TITLE
Autodraft mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ if you change the field later you may need to manually update all existing colle
 3. When editing an existing collection the moderation value will change automatically to `Draft`.
 4. When retrieving a collection entry (or list of entries) only entries with moderation value of `Published` or `Draft` (if there is a `Published` revision before the `Draft` one) will be returned.
 
+### Options
+The moderation field supports the following options:
+
+* `autodraft` (default: _true_) If set to _false_, entries that are being edited wont be set to `Draft`
+
 ### Localization
 
 The moderation fields supports localization as any other Cockpit field, just enable the localization option in the field configuration.

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -138,6 +138,25 @@ $this->module('moderation')->extend([
     return $this->app->storage->remove('moderation/schedule', ['_oid' => $id, '_lang' => $lang]);
   },
 
+  'getLastPublished' => function (array $params) {
+    $revisions = $this->app->helper('revisions')->getList($params['id']);
+    if ($revisions) {
+      $moderationField = $this->getModerationField($params['collection']);
+      if ($moderationField) {
+        $field = $moderationField['name'];
+        if ($moderationField['localize'] && $params['lang']) {
+          $field .= "_{$params['lang']}";
+        }
+        foreach ($revisions as $revision) {
+          if ($revision['data'][$field] != "Draft") {
+            return $revision['data'][$field];
+          }
+        }
+      }
+    }
+    return "Unpublished";
+  },
+
 ]);
 
 // Incldude admin.

--- a/views/partials/entry-aside.php
+++ b/views/partials/entry-aside.php
@@ -62,7 +62,7 @@
     </label>
     <div class="uk-margin-small-top">
       <span class="uk-badge uk-badge-outline">
-        {originalModeration[lang] !== entry[moderation_field] ? App.i18n.get("Change to:") : App.i18n.get("Save as:")} <strong>{App.i18n.get(entry[moderation_field])}</strong>
+        {originalModeration[localized ? lang : ''] !== entry[moderation_field] ? App.i18n.get("Change to:") : App.i18n.get("Save as:")} <strong>{App.i18n.get(entry[moderation_field])}</strong>
       </span>
     </div>
     <select bind="entry.{moderation_field}">

--- a/views/partials/entry-aside.php
+++ b/views/partials/entry-aside.php
@@ -197,14 +197,15 @@
     if(!silent) {
       App.ui.notify(App.i18n.get('Entry moderation status changed to') + ' <strong>' + status + '</strong>', 'success');
     }
+    App.$('#save-and-publish').hide();
     if (status === 'Draft') {
-      App.$('#save-and-publish').show();
+      if ($this.autodraft) {
+        App.$('#save-and-publish').show();
+      }
       App.$('#save-entry-button').removeClass('uk-button-danger uk-button-success').addClass('uk-button-primary').html(App.i18n.get('Save Draft')).show();
     } else if (status === 'Published') {
-      App.$('#save-and-publish').hide();
       App.$('#save-entry-button').removeClass('uk-button-primary uk-button-danger').addClass('uk-button-success').html(App.i18n.get('Save Published')).show();
     } else if (status === 'Unpublished') {
-      App.$('#save-and-publish').hide();
       App.$('#save-entry-button').removeClass('uk-button-primary uk-button-success').addClass('uk-button-danger').html(App.i18n.get('Save Unpublished')).show();
     }
   }

--- a/views/partials/entry-aside.php
+++ b/views/partials/entry-aside.php
@@ -134,15 +134,18 @@
     $this.localize = $this.field[0].localize || false;
     $this.moderation_field_name = $this.field[0].name;
     $this.moderation_field = getModerationField();
+    $this.autodraft = typeof $this.field[0].options.autodraft === "undefined" ? true : !!$this.field[0].options.autodraft;
+    var currentModeration = $this.entry[$this.moderation_field_name];
 
-    $this.originalModeration[''] = $this.entry[$this.moderation_field_name] || 'Draft';
-    if ($this.entry[$this.moderation_field_name] !== 'Unpublished') {
+    $this.originalModeration[''] = currentModeration || 'Draft';
+    if (currentModeration === null || ($this.autodraft && currentModeration !== 'Unpublished')) {
         $this.entry[$this.moderation_field_name] =  'Draft';
     }
     if ($this.localize) {
       for (var l of $this.languages) {
-        $this.originalModeration[l.code] = $this.entry[$this.moderation_field_name + "_" + l.code] || 'Draft';
-        if ($this.entry[$this.moderation_field_name + "_" + l.code] !== 'Unpublished') {
+        var currentLocalizedModeration = $this.entry[$this.moderation_field_name + "_" + l.code];
+        $this.originalModeration[l.code] = currentLocalizedModeration || 'Draft';
+        if (currentLocalizedModeration === null || ($this.autodraft && currentLocalizedModeration !== 'Unpublished')) {
           $this.entry[$this.moderation_field_name + "_" + l.code] = 'Draft';
         }
       }
@@ -153,7 +156,7 @@
       sidebar.insertBefore(document.querySelector('.moderation-status'), sidebar.childNodes[0]);
       App.$('cp-actionbar .uk-container button.uk-button-primary').attr('id', 'save-entry-button');
       App.$('cp-actionbar .uk-container').prepend(App.$('#save-and-publish'));
-      updateActions($this.entry[$this.moderation_field]);
+      updateActions($this.entry[$this.moderation_field], !$this.autodraft);
     }, 50);
 
     if (this.canSchedule && this.entry._id) {
@@ -185,8 +188,10 @@
       : $this.moderation_field_name;
   }
 
-  function updateActions(status) {
-    App.ui.notify(App.i18n.get('Entry moderation status changed to') + ' <strong>' + status + '</strong>', 'success');
+  function updateActions(status, silent = false) {
+    if(!silent) {
+      App.ui.notify(App.i18n.get('Entry moderation status changed to') + ' <strong>' + status + '</strong>', 'success');
+    }
     if (status === 'Draft') {
       App.$('#save-and-publish').show();
       App.$('#save-entry-button').removeClass('uk-button-danger uk-button-success').addClass('uk-button-primary').html(App.i18n.get('Save Draft')).show();

--- a/views/partials/entry-aside.php
+++ b/views/partials/entry-aside.php
@@ -55,10 +55,10 @@
   <label class="uk-text-small">@lang('Moderation')</label>
   <div class="uk-width-1-1 uk-form-select uk-moderation-element uk-moderation-{ entry[moderation_field] }">
     <label class="uk-text">
-      <i if="{originalModeration[lang] == 'Unpublished'}" class="icon-Unpublished uk-icon-circle-o"></i>
-      <i if="{originalModeration[lang] == 'Draft'}" class="icon-Draft uk-icon-pencil"></i>
-      <i if="{originalModeration[lang] == 'Published'}" class="icon-Published uk-icon-circle"></i>
-      <strong>@lang('Status:')</strong> {App.i18n.get(originalModeration[lang])}
+      <i if="{originalModeration[localized ? lang : ''] == 'Unpublished'}" class="icon-Unpublished uk-icon-circle-o"></i>
+      <i if="{originalModeration[localized ? lang : ''] == 'Draft'}" class="icon-Draft uk-icon-pencil"></i>
+      <i if="{originalModeration[localized ? lang : ''] == 'Published'}" class="icon-Published uk-icon-circle"></i>
+      <strong>@lang('Status:')</strong> {App.i18n.get(originalModeration[localized ? lang : ''])} <span if="{originalModeration[localized ? lang : ''] === 'Draft' && lastPublished}">({lastPublished})</span>
     </label>
     <div class="uk-margin-small-top">
       <span class="uk-badge uk-badge-outline">
@@ -97,6 +97,7 @@
   $this.canSchedule = {{ json_encode($enabled) }};
   $this.schedule = false;
   $this.langLabel = null;
+  $this.lastPublished = "";
 
   var oldXHROpen = window.XMLHttpRequest.prototype.open;
   window.XMLHttpRequest.prototype.open = function(method, url, async, user, password) {
@@ -180,6 +181,10 @@
     if (this.entry._id && data[0] && data[1] && data[0] === 'entry.' + $this.moderation_field) {
       updateActions(data[1]);
     }
+    App.callmodule('moderation:getLastPublished', { id: $this.entry._id, collection: $this.collection.name, lang: $this.lang || "" }).then(function(data) {
+      $this.lastPublished = data.result;
+      $this.update();
+    });
   });
 
   function getModerationField() {


### PR DESCRIPTION
Hello Paulo! I hope that you are well in these pandemic times!

Our organization has been using this addon for more than a year now and when reviewing the feedback I have gotten it has become apparent that there are some standard behaviours that are somewhat problematic for us:

1. It gets confusing that the entry is set to Draft on editing. Most of the time we want the moderation status to stay the same as when we started to edit the entry (ie, keep drafting or modify the already published entry)
1. It is hard to tell if the entry was un- or published before the current draft (ie. what will be returned from the api)
1. Sometimes an editor press the save-and-publish button just because it is there and very invitingly green (people are sheep)
1. The moderation status, save verb and icons are bugged

This PR fixes these things in this fashion:
* Adds an autodraft field option that doesn't set Draft on edited entries and only displays the save-entry button
* Displays the latest non-draft status beside the status if it is Draft
* Bugfixes the moderation status, save verb and icons