### PR TITLE
Bugfix overwriting getLastPublished module method

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -138,7 +138,7 @@ $this->module('moderation')->extend([
     return $this->app->storage->remove('moderation/schedule', ['_oid' => $id, '_lang' => $lang]);
   },
 
-  'getLastPublished' => function (array $params) {
+  'getLastPublishedStatus' => function (array $params) {
     $revisions = $this->app->helper('revisions')->getList($params['id']);
     if ($revisions) {
       $moderationField = $this->getModerationField($params['collection']);

--- a/views/partials/entry-aside.php
+++ b/views/partials/entry-aside.php
@@ -181,7 +181,7 @@
     if (this.entry._id && data[0] && data[1] && data[0] === 'entry.' + $this.moderation_field) {
       updateActions(data[1]);
     }
-    App.callmodule('moderation:getLastPublished', { id: $this.entry._id, collection: $this.collection.name, lang: $this.lang || "" }).then(function(data) {
+    App.callmodule('moderation:getLastPublishedStatus', { id: $this.entry._id, collection: $this.collection.name, lang: $this.lang || "" }).then(function(data) {
       $this.lastPublished = data.result;
       $this.update();
     });


### PR DESCRIPTION
Hey again!

I fucked up royaly by creating a new module method with the same name as the one used in the filter hooks.
This PR fixes this blatant error and reminds me why I should test both the cockpit cms gui AND the api.

Cheers!